### PR TITLE
Fix versioning syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ jobs:
 
 Release syntax is taken from the official [JuleC releases](https://github.com/julelang/jule/releases).
 
-- `latest` and `current` for the latest commit.
+- `latest` and `current` for the latest release.
+- `dev` for the latest commit.
 - `beta-0.x.x` (there are no stable releases for now).
 
 ### Architecture

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: gray-dark
 inputs:
   version:
-    description: "The version of JuleC that will be downloaded. Use \"latest\" for the latest Git version."
+    description: "The version of JuleC that will be downloaded. Use \"latest\" for the latest stable release."
     required: true
     default: "latest"
   directory:
@@ -45,9 +45,17 @@ runs:
       shell: bash
       run: |
         if [[ ${{ inputs.version }} == "latest" ]] || [[ ${{ inputs.version }} == "current" ]]; then
+          RELEASES=$(curl -s https://api.github.com/repos/julelang/jule/releases)
+          LATEST_RELEASE=$(echo "$RELEASES" | jq -r '.[] | select(.draft == false) | .tarball_url' | head -n 1)
+
+          wget $LATEST_RELEASE -O julec.tar.gz
+          mkdir -p ${{ inputs.directory }}/julec-latest
+          tar -xzf julec.tar.gz -C ${{ inputs.directory }}/julec-latest
+        elif [[ ${{ inputs.version }} == "dev" ]]; then
           git clone https://github.com/julelang/jule.git ${{ inputs.directory }}/julec-${{ inputs.version }}
         else
           wget https://github.com/julelang/jule/archive/refs/tags/jule-${{ inputs.version }}.tar.gz -O julec.tar.gz
+          mkdir -p ${{ inputs.directory }}/julec-${{ inputs.version }}
           tar -xzf julec.tar.gz -C ${{ inputs.directory }}/julec-${{ inputs.version }}
         fi
     - name: Get JuleC IR


### PR DESCRIPTION
Things added/changed:

- Fix versioning syntax.
  - `dev` is for the **latest commit**.
  - `latest` and `current` is for the **latest release**, whether it's a pre-release or the latest.
